### PR TITLE
fix: remove stale pre-restructure URLs from sitemaps

### DIFF
--- a/sitemap-international.xml
+++ b/sitemap-international.xml
@@ -27,14 +27,6 @@
     <xhtml:link rel="alternate" hreflang="us" href="https://equalsmoney.com/us/contact"/>
   </url>
   <url>
-    <loc>https://equalsmoney.com/account-features/control-spend</loc>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/account-features/control-spend"/>
-    <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/controle-des-depenses"/>
-    <xhtml:link rel="alternate" hreflang="es-es" href="https://equalsmoney.com/es-es/control-de-gastos"/>
-    <xhtml:link rel="alternate" hreflang="nl-nl" href="https://equalsmoney.com/nl-nl/budgetbeheer"/>
-    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/control-spend"/>
-  </url>
-  <url>
     <loc>https://equalsmoney.com/cookie-policy</loc>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/cookie-policy"/>
     <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/politique-de-cookies"/>
@@ -53,21 +45,19 @@
     <xhtml:link rel="alternate" hreflang="us" href="https://equalsmoney.com/us/expense-management"/>
   </url>
   <url>
-    <loc>https://equalsmoney.com/international-payments</loc>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/international-payments"/>
+    <loc>https://equalsmoney.com/business-payments/international-payments</loc>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/business-payments/international-payments"/>
     <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/paiements-internationaux"/>
     <xhtml:link rel="alternate" hreflang="es-es" href="https://equalsmoney.com/es-es/pagos-internacionales"/>
     <xhtml:link rel="alternate" hreflang="nl-nl" href="https://equalsmoney.com/nl-nl/internationale-betalingen"/>
-    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/international-payments"/>
-    <xhtml:link rel="alternate" hreflang="us" href="https://equalsmoney.com/us/international-payments"/>
+    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/business-payments/international-payments"/>
   </url>
   <url>
-    <loc>https://equalsmoney.com/accounts/multi-currency-account</loc>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/accounts/multi-currency-account"/>
+    <loc>https://equalsmoney.com/business-accounts/multi-currency-business-account</loc>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://equalsmoney.com/business-accounts/multi-currency-business-account"/>
     <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/compte-multidevise"/>
     <xhtml:link rel="alternate" hreflang="es-es" href="https://equalsmoney.com/es-es/cuenta-multidivisa"/>
     <xhtml:link rel="alternate" hreflang="nl-nl" href="https://equalsmoney.com/nl-nl/multi-valutarekening"/>
-    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/multi-currency-account"/>
   </url>
   <url>
     <loc>https://equalsmoney.com/privacy</loc>
@@ -116,8 +106,8 @@
     <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/cartes-de-frais-professionnels-prepayees"/>
     <xhtml:link rel="alternate" hreflang="es-es" href="https://equalsmoney.com/es-es/tarjetas-de-gastos-prepagadas"/>
     <xhtml:link rel="alternate" hreflang="nl-nl" href="https://equalsmoney.com/nl-nl/prepaid-zakelijke-onkostenkaarten"/>
-    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/prepaid-business-cards"/>
-    <xhtml:link rel="alternate" hreflang="us" href="https://equalsmoney.com/us/prepaid-expense-cards"/>
+    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/expense-cards/prepaid-business-cards"/>
+    <xhtml:link rel="alternate" hreflang="us" href="https://equalsmoney.com/us/prepaid-business-cards"/>
   </url>
   <url>
     <loc>https://equalsmoney.com/expense-cards/business-debit-cards</loc>
@@ -125,6 +115,6 @@
     <xhtml:link rel="alternate" hreflang="fr-fr" href="https://equalsmoney.com/fr-fr/cartes-de-debit-professionnelles"/>
     <xhtml:link rel="alternate" hreflang="es-es" href="https://equalsmoney.com/es-es/tarjetas-de-debito-comerciales"/>
     <xhtml:link rel="alternate" hreflang="nl-nl" href="https://equalsmoney.com/nl-nl/zakelijke-betaalkaarten"/>
-    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/business-debit-cards"/>
+    <xhtml:link rel="alternate" hreflang="en-be" href="https://equalsmoney.com/en-be/expense-cards/business-debit-cards"/>
   </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -22,10 +22,7 @@
 		<loc>https://equalsmoney.com/enterprise/api</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/accounts/business-current-account</loc>
-	</url>
-	<url>
-		<loc>https://equalsmoney.com/accounts/start-up-business-account</loc>
+		<loc>https://equalsmoney.com/business-accounts/business-current-account</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/environment</loc>
@@ -52,10 +49,10 @@
 		<loc>https://equalsmoney.com/use-cases/travel/tour-operators</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/payments/international-payments</loc>
+		<loc>https://equalsmoney.com/business-payments/international-payments</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/accounts/multi-currency-business-account</loc>
+		<loc>https://equalsmoney.com/business-accounts/multi-currency-business-account</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/financial-calculators</loc>
@@ -76,7 +73,7 @@
 		<loc>https://equalsmoney.com/expense-cards/prepaid-business-cards</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/payments/domestic-payments</loc>
+		<loc>https://equalsmoney.com/business-payments/domestic</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/expense-cards/corporate-cards</loc>
@@ -91,7 +88,7 @@
 		<loc>https://equalsmoney.com/industry/travel</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/payments/bulk-payments</loc>
+		<loc>https://equalsmoney.com/business-payments/mass-payments</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/cookie-policy</loc>
@@ -130,7 +127,7 @@
 		<loc>https://equalsmoney.com/blog</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/payments/currency-forward-contracts</loc>
+		<loc>https://equalsmoney.com/corporate-fx/fx-forward-contract</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/en-be</loc>
@@ -146,9 +143,6 @@
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/get-started</loc>
-	</url>
-	<url>
-		<loc>https://equalsmoney.com/use-cases/ecommerce</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/banking-as-a-service</loc>
@@ -223,7 +217,7 @@
 		<loc>https://equalsmoney.com/es-es</loc>
 	</url>
 	<url>
-		<loc>https://equalsmoney.com/payments/corporate-foreign-exchange</loc>
+		<loc>https://equalsmoney.com/corporate-fx</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/currencies/forecasts/gbpusd</loc>
@@ -287,9 +281,6 @@
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/economic-calendar/events/cpih</loc>
-	</url>
-	<url>
-		<loc>https://equalsmoney.com/international-payments/register-now</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/financial-calculators/corporation-tax-calculator-uk</loc>
@@ -557,9 +548,6 @@
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/blog/market-report-28-02-24</loc>
-	</url>
-	<url>
-		<loc>https://equalsmoney.com/international-payments/rate-watch</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/business-expenses/accrual-accounting</loc>
@@ -1844,9 +1832,6 @@
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/currencies/majors/huf</loc>
-	</url>
-	<url>
-		<loc>https://equalsmoney.com/passport-to-growth</loc>
 	</url>
 	<url>
 		<loc>https://equalsmoney.com/financial-glossary/s-p-500-index</loc>


### PR DESCRIPTION
> [!WARNING]
> **Merge = production deploy.** Merging to `develop` auto-deploys to production via GitHub Pages. CloudFront caches for 600s, so changes propagate within ~10 minutes of merge. After merging, resubmit the sitemaps in Google Search Console. **This PR is intentionally a draft — do not merge without sign-off.**

Notion: https://app.notion.com/37633a4e397081a1b9ffe40c66aa8a48

## Findings

- `sitemap.xml` was generated by Sitebulb on **2025-09-22**, which predates the site URL restructure (`/payments/*` → `/business-payments/*`, `/accounts/*` → `/business-accounts/*`, `/payments/corporate-foreign-exchange` → `/corporate-fx`, etc.), so it still listed the old URLs, all of which now 301.
- `sitemap-international.xml` had the same problem in its `<loc>`s plus several `xhtml:link` alternate hrefs that 301 or 404 (worst: `/en-be/multi-currency-account` → 404).
- Every URL below was HEAD-checked live (~1 req/sec). All replacement targets return a **direct 200**.

## Changes

### sitemap.xml — replacements (old → new, all old URLs 301 to the new)

| Old (301) | New (direct 200) |
|---|---|
| `/payments/international-payments` | `/business-payments/international-payments` |
| `/payments/domestic-payments` | `/business-payments/domestic` |
| `/payments/bulk-payments` | `/business-payments/mass-payments` |
| `/payments/currency-forward-contracts` | `/corporate-fx/fx-forward-contract` |
| `/payments/corporate-foreign-exchange` | `/corporate-fx` |
| `/accounts/business-current-account` | `/business-accounts/business-current-account` |
| `/accounts/multi-currency-business-account` | `/business-accounts/multi-currency-business-account` |

### sitemap.xml — removals

- `/accounts/start-up-business-account` — 301s to `/business-accounts/business-current-account`, which is now already present (dedupe; two old URLs collapse onto one target)
- `/use-cases/ecommerce` — 301; target `/case-studies` already present
- `/passport-to-growth` — 301; target `/` already present
- `/international-payments/rate-watch` — redirect chain
- `/international-payments/register-now` — live duplicate of `/register-now` (already present); canonical decision is a Webflow follow-up

### sitemap-international.xml

- `<loc>` `/international-payments` → `/business-payments/international-payments` (en-gb alternate updated to match); `en-be` alternate fixed to `/en-be/business-payments/international-payments` (old href 301'd); `us` alternate **removed** — `/us/international-payments` 301s to the `/us` homepage, which is not an equivalent page
- `<loc>` `/accounts/multi-currency-account` → `/business-accounts/multi-currency-business-account` (en-gb alternate updated to match); `en-be` alternate `/en-be/multi-currency-account` **removed** (404, no replacement page exists)
- `/account-features/control-spend` entry **removed** rather than re-pointed: the ticket's target `/expense-management` already has its own entry with the correct expense-management hreflang cluster, so re-pointing would have created a duplicate `<loc>`. The control-spend locale pages (`/fr-fr/controle-des-depenses`, `/es-es/control-de-gastos`, `/nl-nl/budgetbeheer`) remain listed in `sitemap.xml`
- Prepaid business cards entry: `en-be` alternate fixed to `/en-be/expense-cards/prepaid-business-cards`; `us` alternate fixed to `/us/prepaid-business-cards` (old hrefs 301'd)
- Business debit cards entry: `en-be` alternate fixed to `/en-be/expense-cards/business-debit-cards` (old href 301'd)

## Verification

- `xmllint --noout` passes on both files
- Zero duplicate `<loc>`s in each file (checked via sort/uniq)
- Full HEAD sweep: all 8 old `/payments/*` + `/accounts/*` URLs confirmed 301; all 82 unique alternate hrefs in `sitemap-international.xml` checked (all 200 except the 7 fixed/removed above); final sweep over all 11 changed/added URLs — **all direct 200**

## Backwards compatibility

- Sitemaps are hints to crawlers, not routing config — nothing user-facing changes
- All removed/replaced URLs keep their live Webflow 301 redirects; no redirect rules are changed by this PR
- `robots.txt` untouched; it continues to reference all three sitemaps
- `sitemap-news.xml`, `payment_purposes.json`, README untouched

## Out-of-scope stale entries noticed (not changed here)

`sitemap.xml` also contains standalone en-be locs that are stale: `/en-be/multi-currency-account` (404), `/en-be/international-payments` (301), `/en-be/control-spend` (301). Left as-is because they were outside this ticket's verified change list — the Sitebulb re-crawl below is the durable fix.

## Webflow follow-ups (not this PR)

- ~35% of pages missing meta descriptions; `/en-be` locale missing **all** meta descriptions
- Missing `og:site_name` / `og:image` on international homepages; inconsistent `twitter:card`
- Canonical decisions needed: `/register-now` vs `/international-payments/register-now`, and `/faq` vs `/faqs/*`
- Durable fix: Sitebulb re-crawl and regenerate sitemaps (owner: d.gouldman)
- `sitemap-news.xml` is >1 year stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)